### PR TITLE
Crystal shard rates buffs

### DIFF
--- a/src/simulation/misc/Gauntlet.ts
+++ b/src/simulation/misc/Gauntlet.ts
@@ -59,7 +59,7 @@ const StandardInnerTable = new LootTable()
 	.add("Coins", [20_000, 80_000]);
 
 const StandardTable = new LootTable()
-	.every("Crystal shard", [3, 7])
+	.every("Crystal shard", [5, 9])
 	.every(StandardInnerTable, 2)
 	.tertiary(25, "Clue scroll (elite)")
 	.tertiary(120, "Crystal weapon seed")
@@ -104,7 +104,7 @@ const CorruptedInnerTable = new LootTable()
 
 const CorruptedTable = new LootTable()
 	// Gauntlet cape is given manually in OSB
-	.every("Crystal shard", [5, 9])
+	.every("Crystal shard", [7, 12])
 	.every(CorruptedInnerTable, 3)
 	.tertiary(20, "Clue scroll (elite)")
 	.tertiary(50, "Crystal weapon seed")

--- a/src/simulation/openables/ElvenCrystalChest.ts
+++ b/src/simulation/openables/ElvenCrystalChest.ts
@@ -20,7 +20,7 @@ const coinsKeyHalfTable = new LootTable()
 /* Rune armor roll */
 const runeArmorTable = new LootTable()
 	.every("Uncut dragonstone")
-	.every("Crystal shard", [4, 6])
+	.every("Crystal shard", [7, 9])
 	.add("Rune platelegs", 1, 1)
 	.add("Rune plateskirt", 1, 1);
 
@@ -56,7 +56,7 @@ const ElvenCrystalChestTable = new LootTable()
 		itemTupleToTable([
 			["Uncut dragonstone", 1],
 			["Coins", [30_000, 50_000]],
-			["Crystal shard", [8, 13]],
+			["Crystal shard", [13, 19]],
 		]),
 		1,
 		20,
@@ -64,7 +64,7 @@ const ElvenCrystalChestTable = new LootTable()
 	.add(
 		itemTupleToTable([
 			["Uncut dragonstone", 1],
-			["Crystal shard", [20, 30]],
+			["Crystal shard", [25, 35]],
 		]),
 		1,
 		17,
@@ -117,7 +117,7 @@ const ElvenCrystalChestTable = new LootTable()
 	.add(
 		itemTupleToTable([
 			["Uncut dragonstone", 1],
-			["Crystal acorn", [1, 2]],
+			["Crystal acorn", [4, 6]],
 		]),
 		1,
 		7,

--- a/src/simulation/openables/Implings.ts
+++ b/src/simulation/openables/Implings.ts
@@ -260,7 +260,7 @@ export const CrystalImpling = new SimpleOpenable({
 	table: new LootTable()
 		.add("Amulet of power", [5, 7])
 		.add("Crystal acorn")
-		.add("Crystal shard", [5, 10])
+		.add("Crystal shard", [30, 40])
 		.add("Dragonstone amulet")
 		.add("Dragonstone", 2)
 		.add("Ruby bolt tips", [50, 125])


### PR DESCRIPTION
### Description:

Crystal shard rates were recently buffed in OSRS.

### Changes:
-Regular Gauntlet: 5-9 shards, up from 3-7. 
-Corrupted Gauntlet: 7-12 shards, up from 5-9. 
-Crystal Chest: Buffed the quantity of Acorns to 4-6 and quantity of Shards by ~50%. 
-Crystal Impling: 30-40 Shards, up from 5-10. 

-   [] I have tested all my changes thoroughly.
