### PR TITLE
Add loot table options (for Araxxor)

### DIFF
--- a/src/simulation/monsters/bosses/Araxxor.ts
+++ b/src/simulation/monsters/bosses/Araxxor.ts
@@ -61,9 +61,11 @@ const AraxxorTable = new LootTable()
 	.add("Bark", 15, 1)
 	.add(RareDropTable);
 
+const DestroyedTable = new LootTable().tertiary(50, "Clue scroll (elite)").tertiary(1500, "Nid");
+
 export const Araxxor = new SimpleMonster({
 	id: 13668,
 	name: "Araxxor",
-	table: AraxxorTable,
+	table: [AraxxorTable, DestroyedTable],
 	aliases: ["araxxor"],
 });

--- a/src/structures/LootTable.ts
+++ b/src/structures/LootTable.ts
@@ -49,6 +49,7 @@ export interface LootTableRollOptions {
 	 */
 	tertiaryItemPercentageChanges?: Map<string, number>;
 	targetBank?: Bank;
+	table?: number;
 }
 
 export default class LootTable {

--- a/src/structures/SimpleMonster.ts
+++ b/src/structures/SimpleMonster.ts
@@ -62,9 +62,7 @@ export default class SimpleMonster extends Monster {
 			: undefined;
 
 		if (!canGetBrimKey && !wildySlayer && !options.inCatacombs && !options.onSlayerTask) {
-			if (this.table) {
-				rollTable?.roll(quantity, lootTableOptions);
-			}
+			rollTable?.roll(quantity, lootTableOptions);
 			if (this.customKillLogic) {
 				for (let i = 0; i < quantity; i++) {
 					this.customKillLogic(options, loot);

--- a/src/structures/SimpleMonster.ts
+++ b/src/structures/SimpleMonster.ts
@@ -10,11 +10,11 @@ import {
 	getTotemChanceFromHP,
 } from "../util/util";
 import Bank from "./Bank";
-import type LootTable from "./LootTable";
+import LootTable from "./LootTable";
 import Monster from "./Monster";
 
 interface SimpleMonsterOptions extends MonsterOptions {
-	table?: LootTable;
+	table?: LootTable | LootTable[];
 	onTaskTable?: LootTable;
 	wildyCaveTable?: LootTable;
 	pickpocketTable?: LootTable;
@@ -22,7 +22,7 @@ interface SimpleMonsterOptions extends MonsterOptions {
 }
 
 export default class SimpleMonster extends Monster {
-	public table?: LootTable;
+	public table?: LootTable | LootTable[];
 	public onTaskTable?: LootTable;
 	public wildyCaveTable?: LootTable;
 	public pickpocketTable?: LootTable;
@@ -31,7 +31,9 @@ export default class SimpleMonster extends Monster {
 	constructor(options: SimpleMonsterOptions) {
 		let allItems: number[] = [];
 		if (options.table) {
-			allItems = allItems.concat(options.table.allItems);
+			for (const table of options.table instanceof LootTable ? [options.table] : options.table) {
+				allItems = allItems.concat(table.allItems);
+			}
 		}
 		if (options.pickpocketTable) {
 			allItems = allItems.concat(options.pickpocketTable.allItems);
@@ -53,9 +55,16 @@ export default class SimpleMonster extends Monster {
 			...options.lootTableOptions,
 			targetBank: loot,
 		};
+		const rollTable = this.table
+			? this.table instanceof LootTable
+				? this.table
+				: this.table[lootTableOptions.table ? lootTableOptions.table : 0]
+			: undefined;
 
 		if (!canGetBrimKey && !wildySlayer && !options.inCatacombs && !options.onSlayerTask) {
-			this.table?.roll(quantity, lootTableOptions);
+			if (this.table) {
+				rollTable?.roll(quantity, lootTableOptions);
+			}
 			if (this.customKillLogic) {
 				for (let i = 0; i < quantity; i++) {
 					this.customKillLogic(options, loot);
@@ -96,11 +105,11 @@ export default class SimpleMonster extends Monster {
 					this.onTaskTable.roll(1, lootTableOptions);
 				} else {
 					// Monster doesn't have a unique on-slayer table
-					this.table?.roll(1, lootTableOptions);
+					rollTable?.roll(1, lootTableOptions);
 				}
 			} else {
 				// Not on slayer task
-				this.table?.roll(1, lootTableOptions);
+				rollTable?.roll(1, lootTableOptions);
 			}
 			if (this.customKillLogic) {
 				this.customKillLogic(options, loot);


### PR DESCRIPTION
### Description:

- Changed loot table to be potentially a list of tables that are chosen using `lootTableOptions` coming from osb command. 
- Applied at Araxxor where the options are regular or destroyed loot, should be used again when ice and fire giant bosses come out as they are due to have optional loot mechanics.

### Changes:

-  Change `SimpleMonster.table` to optionally be a list
-  Add `table` modifier to `lootTableOptions` to select which table to roll from in list.

-   [x] I have tested all my changes thoroughly.
