### PR TITLE
Make DT2 rings tradeable

### DIFF
--- a/scripts/prepareItems.ts
+++ b/scripts/prepareItems.ts
@@ -329,6 +329,34 @@ export default async function prepareItems(): Promise<void> {
 			};
 		}
 
+		if (item.name === "Ultor ring") {
+			item = {
+				...allItems[28_307],
+				id: item.id,
+			};
+		}
+
+		if (item.name === "Bellator ring") {
+			item = {
+				...allItems[28_316],
+				id: item.id,
+			};
+		}
+
+		if (item.name === "Magus ring") {
+			item = {
+				...allItems[28_313],
+				id: item.id,
+			};
+		}
+
+		if (item.name === "Venator ring") {
+			item = {
+				...allItems[28_310],
+				id: item.id,
+			};
+		}
+
 		for (const delKey of [
 			"quest_item",
 			"placeholder",


### PR DESCRIPTION
### Description:

-  Same concept as https://github.com/oldschoolgg/oldschooljs/pull/409. Added ID override to the correct IDs for osjs lookup, but the outputted items have the beta ID still, so rings become automatically tradeable. Again, same issue of having price 0, but can be sold on ge.

### Changes:

-   Make DT2 rings tradeable by getting data from correct IDs

-   [x] I have tested all my changes thoroughly.
