### PR TITLE
update Armoured zombie loottable

### DIFF
--- a/src/simulation/monsters/low/a-f/ArmouredZombie.ts
+++ b/src/simulation/monsters/low/a-f/ArmouredZombie.ts
@@ -3,39 +3,41 @@ import SimpleMonster from "../../../../structures/SimpleMonster";
 import HerbDropTable from "../../../subtables/HerbDropTable";
 import { GemTable } from "../../../subtables/RareDropTable";
 
+// Use the Zemouregal's Fort verions: https://oldschool.runescape.wiki/w/Armoured_zombie_(Zemouregal%27s_Fort)#Melee,_1
 export const ArmouredZombieTable = new LootTable({ limit: 128 })
 	.every("Bones")
 
 	/* Runes and ammunition */
-	.add("Pure essence", [20, 50], 12)
+	.add("Pure essence", [20, 50], 11)
 	.add("Adamant arrow", 12, 8)
-	.add("Blood rune", [4, 10], 4)
-	.add("Cosmic rune", [10, 20], 3)
-	.add("Nature rune", [4, 10], 2)
-	.add("Chaos rune", [10, 20], 1)
-	.add("Death rune", [4, 10], 1)
+	.add("Blood rune", [6, 14], 4)
+	.add("Cosmic rune", [15, 30], 3)
+	.add("Nature rune", [6, 16], 2)
+	.add("Death rune", [6, 14], 1)
+	.add("Chaos rune", [15, 30], 1)
 
 	/* Herbs */
-	.add(HerbDropTable, 1, 43)
+	.add(HerbDropTable, 1, 45)
 
 	/* Other */
-	.add("Coins", [50, 400], 31)
-	.add("Oak plank", 5, 6)
-	.add("Plank", 10, 5)
-	.add("Adamant mace", 1, 3)
-	.add("Coins", [10, 20], 3)
-	.add("Teak plank", 2, 2)
-	.add("Adamant kiteshield", 1, 1)
-	.add("Eye of newt", [2, 6], 1)
+	.add("Coins", [200, 600], 30)
+	.add("Oak plank", 6, 6)
+	.add("Plank", 12, 5)
+	.add("Coins", [20, 30], 3)
+	.add("Rune mace", 1, 3)
+	.add("Teak plank", 3, 2)
+	.add("Eye of newt", [4, 8], 1)
+	.add("Rune kiteshield", 1, 1)
 	.add("Fishing bait", 6, 1)
 
 	/* Gem drop table */
 	.add(GemTable, 1, 1)
 
 	/* Tertiary */
-	.tertiary(128, "Clue scroll (hard)")
-	.tertiary(800, "Broken zombie axe")
-	.tertiary(5000, "Zombie champion scroll");
+	.tertiary(600, "Broken zombie helmet")
+	.tertiary(600, "Broken zombie axe")
+	.tertiary(5000, "Zombie champion scroll")
+	.tertiary(128, "Clue scroll (hard)");
 
 export default new SimpleMonster({
 	id: 12_720,


### PR DESCRIPTION
### Description:
Update armoued zombies to use the Zemouregal's version. More detail & community poll here: https://discord.com/channels/342983479501389826/1008945789860589628/1307093517230805002

Broken zombie helmet(30324) still isn't inside `0xNeffarion/osrsreboxed-db` when doing prepItems. I'll make it a draft until then.

### Changes:
- armoured zombies loottable update.
- I left the mob ID the same as to not cause any conflicts in the db.

- [X] I have tested all my changes thoroughly.
- `yarn dev` wasn't run.